### PR TITLE
chore: typo on license

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "textwrap"
   ],
   "author": "tecfu",
-  "license": "gpl-2.0",
+  "license": "GPL-2.0",
   "bugs": {
     "url": "https://github.com/tecfu/breakword/issues"
   },


### PR DESCRIPTION
Hi there,

I think it's small but I got this warning from Rome cli.
```

✖ rome check --apply:

 node_modules/breakword/package.json:22:14 parse/spdxLicense ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  × Unknown license gpl-2.0

    20 │   ],
    21 │   "author": "tecfu",
  > 22 │   "license": "gpl-2.0",
       │               ^^^^^^^
    23 │   "bugs": {
    24 │     "url": "https://github.com/tecfu/breakword/issues"

  i Did you mean AFL-2.0?

  - gpl-2.0
  + AFL-2.0

  i Or one of these?

  - ECL-2.0
  - EFL-2.0
  - EPL-2.0
  - GPL-2.0
  - MPL-2.0
  - OSL-2.0
  - PSF-2.0
  - ZPL-2.0

  i The SPDX registry is used to ensure valid and legal licenses. See https://spdx.org/licenses/
    for more information.
```